### PR TITLE
LibraryRenamer:  Added library reference toggles

### DIFF
--- a/LibraryRenamer/Source/MainComponent.cpp
+++ b/LibraryRenamer/Source/MainComponent.cpp
@@ -38,7 +38,25 @@ MainComponent::MainComponent()
 		}
 	};
 
-    setSize(800, 200);
+	// Toggle whether or not to update Guru Sampler Library Name.
+	updateGuruSamplerLibraryToggle.setButtonText("Update Guru Sampler Library reference?  "
+		"Checked will update library name to new name.  Unchecked will leave reference as-is.");
+	updateGuruSamplerLibraryToggle.setToggleState(true, dontSendNotification);
+	addAndMakeVisible(updateGuruSamplerLibraryToggle);
+	updateGuruSamplerLibraryToggle.onClick = [this] {
+		patchConverter.updateGuruSamplerLibraryName = updateGuruSamplerLibraryToggle.getToggleState();
+		};
+
+	// Toggle whether or not to update MIDI Box Library reference name.
+	updateMIDIBoxToggle.setButtonText("Update MIDI Box reference name?  "
+		"Checked will update library name to new library name.  Unchecked will leave reference as-is.");
+	updateMIDIBoxToggle.setToggleState(true, dontSendNotification);
+	addAndMakeVisible(updateMIDIBoxToggle);
+	updateMIDIBoxToggle.onClick = [this] {
+		patchConverter.updateMIDIBoxName = updateMIDIBoxToggle.getToggleState();
+		};
+
+    setSize(800, 310);
 }
 
 void MainComponent::resized()
@@ -52,6 +70,10 @@ void MainComponent::resized()
     library.setBounds(bounds.removeFromTop(24));
 	bounds.removeFromTop(20);
 	outputFolderPath.setBounds(bounds.removeFromTop(24));
+	bounds.removeFromTop(20);
+	updateGuruSamplerLibraryToggle.setBounds(bounds.removeFromTop(35));
+	bounds.removeFromTop(25);
+	updateMIDIBoxToggle.setBounds(bounds.removeFromTop(55));
 }
 
 void MainComponent::paint(Graphics& g)

--- a/LibraryRenamer/Source/MainComponent.h
+++ b/LibraryRenamer/Source/MainComponent.h
@@ -23,6 +23,8 @@ private:
 
     TextEditor library;		        Label libraryLabel;
     TextButton outputFolderPath;    Label outputFolderPathLabel;
+    ToggleButton updateGuruSamplerLibraryToggle;
+    ToggleButton updateMIDIBoxToggle;
 
     String message;
 

--- a/LibraryRenamer/Source/PatchConverter.cpp
+++ b/LibraryRenamer/Source/PatchConverter.cpp
@@ -277,7 +277,8 @@ String PatchConverter::convertGuruSamplerState(String stateInfo)
     String libName = xml->getStringAttribute("osc1LibraryName");
     jassert(libName.isNotEmpty());
 
-    if (xml->getStringAttribute("osc1LibraryName") != "Unify Standard Library")
+    // Be sure user is OK with updating the Guru Sampler Library Name.
+    if (this->updateGuruSamplerLibraryName && xml->getStringAttribute("osc1LibraryName") != "Unify Standard Library")
         xml->setAttribute("osc1LibraryName", libraryName);
 
     MemoryBlock outBlock;
@@ -297,7 +298,8 @@ String PatchConverter::convertMIDIBoxState(String stateInfo)
     String libName = xml->getStringAttribute("libraryName");
     String midiFilePath = xml->getStringAttribute("midiFilePath").replace("\\", "/");
 
-    if (xml->getStringAttribute("libraryName") != "Unify Standard Library")
+    // Be sure user is OK with updating the MIDI Box reference.
+    if (this->updateMIDIBoxName && xml->getStringAttribute("libraryName") != "Unify Standard Library")
     {
         xml->setAttribute("libraryName", libraryName);
 

--- a/LibraryRenamer/Source/PatchConverter.h
+++ b/LibraryRenamer/Source/PatchConverter.h
@@ -7,6 +7,8 @@ public:
     String unifyRootFolderPath;
     String libraryName;
     String outputFolderPath;
+    bool updateGuruSamplerLibraryName = true;
+    bool updateMIDIBoxName = true;
 
 public:
     PatchConverter();


### PR DESCRIPTION
LibraryRenamer now has options to select whether to point Guru Sampler and MIDI Box references to the new library name or keep the names as-is.